### PR TITLE
bump to v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## [Unreleased]
+## [0.2.0] - 2024-04-02
+
+- upgrade active_record-cursor-paginator to 0.2.0
 
 ## [0.1.0] - 2023-09-21
 

--- a/grape-cursor_paginate_helper.gemspec
+++ b/grape-cursor_paginate_helper.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) {|f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'active_record-cursor_paginator'
+  spec.add_dependency 'active_record-cursor_paginator', '0.2.0'
   spec.add_dependency 'grape', '>= 1.7'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/grape/cursor_paginate_helper/version.rb
+++ b/lib/grape/cursor_paginate_helper/version.rb
@@ -2,6 +2,6 @@
 
 module Grape
   module CursorPaginateHelper
-    VERSION = '0.1.0'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
依存する active_record-cursor-paginator のバージョンを指定します

yokaやqwanでは直接的にはこちらのライブラリに依存しているので、こっちのバージョンをあげてから yoka , qwan で bundle  update をする必要がありそうです