### PR TITLE
support grape v3.x

### DIFF
--- a/grape-cursor_paginate_helper.gemspec
+++ b/grape-cursor_paginate_helper.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = 'see https://github.com/ssugiyama/grape-cursor_paginate_helper'
   spec.homepage = 'https://github.com/ssugiyama/grape-cursor_paginate_helper'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.0.0'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'active_record-cursor_paginator'
-  spec.add_dependency 'grape', '>= 1.7'
+  spec.add_dependency 'grape', '>= 2.0'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/grape/cursor_paginate_helper.rb
+++ b/lib/grape/cursor_paginate_helper.rb
@@ -8,7 +8,8 @@ module Grape
 
     DEFAULT_PAGE_SIZE = 10
 
-    params :cursor_paginate do |opts = {}|
+    # Grape 3対応だが、Grape 2でも動作する（Ruby 3以降推奨）
+    params :cursor_paginate do |**opts|
       opts.reverse_merge!(
         per_page: DEFAULT_PAGE_SIZE,
       )
@@ -31,9 +32,10 @@ module Grape
     end
 
     module DSLMethods
-      def cursor_paginate(opts = {})
+      # Grape 3対応だが、Grape 2でも動作する（Ruby 3以降推奨）
+      def cursor_paginate(**opts)
         params do
-          use(:cursor_paginate, opts)
+          use(:cursor_paginate, **opts)
         end
       end
     end


### PR DESCRIPTION
This pull request updates the `CursorPaginateHelper` module to improve compatibility with Grape 3 and Ruby 3 or later, while maintaining backward compatibility with Grape 2. The main changes involve updating method signatures to use keyword arguments, which is the preferred style in newer Ruby versions.

Compatibility improvements:

* Updated the parameter handling in the `params :cursor_paginate` method to use keyword arguments (`**opts`) instead of a positional argument, ensuring compatibility with Grape 3 and Ruby 3+, while still working with Grape 2.
* Updated the `cursor_paginate` DSL method to use keyword arguments (`**opts`) and to pass them correctly to `use(:cursor_paginate, **opts)`, aligning with modern Ruby best practices and Grape 3 requirements.