### PR TITLE
Feature/bump to v0.3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ inherit_mode:
 
 # 自動生成されるものはチェック対象から除外する
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   SuggestExtensions: false
   NewCops: enable
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.3.0] - 2025-12-03
+
+- support grape v3.x
+- drop support for Ruby 2.x and Grape 1.x
+
 ## [0.2.0] - 2024-04-02
 
 - upgrade active_record-cursor-paginator to 0.2.0

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-require "rubocop/rake_task"
+require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
 

--- a/grape-cursor_paginate_helper.gemspec
+++ b/grape-cursor_paginate_helper.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = 'see https://github.com/ssugiyama/grape-cursor_paginate_helper'
   spec.homepage = 'https://github.com/ssugiyama/grape-cursor_paginate_helper'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.0.0'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'active_record-cursor_paginator'
-  spec.add_dependency 'grape', '>= 1.7'
+  spec.add_dependency 'grape', '>= 2.0'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/grape-cursor_paginate_helper.gemspec
+++ b/grape-cursor_paginate_helper.gemspec
@@ -28,9 +28,9 @@ Gem::Specification.new do |spec|
   spec.bindir = 'exe'
   spec.executables = spec.files.grep(%r{\Aexe/}) {|f| File.basename(f) }
   spec.require_paths = ['lib']
-  
+
   spec.add_dependency 'active_record-cursor_paginator', '0.2.0'
   spec.add_dependency 'grape', '>= 2.0'
-  
+
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/grape/cursor_paginate_helper.rb
+++ b/lib/grape/cursor_paginate_helper.rb
@@ -8,7 +8,8 @@ module Grape
 
     DEFAULT_PAGE_SIZE = 10
 
-    params :cursor_paginate do |opts = {}|
+    # Grape 3対応だが、Grape 2でも動作する（Ruby 3以降推奨）
+    params :cursor_paginate do |**opts|
       opts.reverse_merge!(
         per_page: DEFAULT_PAGE_SIZE,
       )
@@ -31,9 +32,10 @@ module Grape
     end
 
     module DSLMethods
-      def cursor_paginate(opts = {})
+      # Grape 3対応だが、Grape 2でも動作する（Ruby 3以降推奨）
+      def cursor_paginate(**opts)
         params do
-          use(:cursor_paginate, opts)
+          use(:cursor_paginate, **opts)
         end
       end
     end

--- a/lib/grape/cursor_paginate_helper/version.rb
+++ b/lib/grape/cursor_paginate_helper/version.rb
@@ -2,6 +2,6 @@
 
 module Grape
   module CursorPaginateHelper
-    VERSION = '0.2.0'
+    VERSION = '0.3.0'
   end
 end

--- a/spec/test_config.rb
+++ b/spec/test_config.rb
@@ -30,7 +30,7 @@ module TestConfig
     private :skipped_adapters
 
     def config
-      @config ||= YAML.safe_load(File.read(config_path))
+      @config ||= YAML.safe_load_file(config_path)
     end
     private :config
 


### PR DESCRIPTION
This pull request updates the gem to version 0.3.0, adding support for Grape v3.x, dropping support for Ruby 2.x and Grape 1.x, and updating dependencies and method signatures to align with the new requirements.

**Compatibility and Dependency Updates:**

* Dropped support for Ruby 2.x and now requires Ruby 3.0 or newer in the gemspec (`grape-cursor_paginate_helper.gemspec`).
* Updated the Grape dependency to require version 2.0 or newer, supporting Grape v3.x and dropping support for Grape 1.x (`grape-cursor_paginate_helper.gemspec`).
* Updated the changelog to reflect the new version, support for Grape 3.x, and dropped support for older Ruby and Grape versions (`CHANGELOG.md`).
* Bumped the gem version to 0.3.0 (`lib/grape/cursor_paginate_helper/version.rb`).

**Code Modernization:**

* Refactored method signatures in `cursor_paginate` and related parameter methods to use keyword arguments (`**opts`) for better compatibility with Grape 3.x and Ruby 3+, while maintaining backward compatibility with Grape 2.x (`lib/grape/cursor_paginate_helper.rb`). [[1]](diffhunk://#diff-8dc8808ecbdb15b9afa6b92a30f83cd46fe345047dcae7ed4a4fedde84335db6L11-R12) [[2]](diffhunk://#diff-8dc8808ecbdb15b9afa6b92a30f83cd46fe345047dcae7ed4a4fedde84335db6L34-R38)